### PR TITLE
feat: user genre refactor와 user genre weight 테이블을 생성

### DIFF
--- a/src/main/java/muse_kopis/muse/actor/application/ActorService.java
+++ b/src/main/java/muse_kopis/muse/actor/application/ActorService.java
@@ -2,6 +2,7 @@ package muse_kopis.muse.actor.application;
 
 import lombok.RequiredArgsConstructor;
 import muse_kopis.muse.actor.domain.Actor;
+import muse_kopis.muse.actor.domain.ActorRepository;
 import muse_kopis.muse.actor.domain.dto.FavoriteActorDto;
 import muse_kopis.muse.auth.oauth.domain.OauthMember;
 import muse_kopis.muse.auth.oauth.domain.OauthMemberRepository;
@@ -21,11 +22,12 @@ public class ActorService {
     private final FavoriteActorRepository favoriteActorRepository;
     private final OauthMemberRepository oauthMemberRepository;
     private final UserGenreRepository userGenreRepository;
+    private final ActorRepository actorRepository;
 
-    public Long favorite(Long memberId, String actorsName, String actorId) {
+    public Long favorite(Long memberId, String actorsName, String actorId, String url) {
         OauthMember oauthMember = oauthMemberRepository.getByOauthMemberId(memberId);
         UserGenre userGenre = userGenreRepository.getUserGenreByOauthMember(oauthMember);
-        Actor actor = new Actor(actorsName, actorId);
+        Actor actor = new Actor(actorsName, actorId, url);
         FavoriteActor favoriteActor = new FavoriteActor(memberId, actor, userGenre);
         FavoriteActor save = favoriteActorRepository.save(favoriteActor);
         return save.id();
@@ -35,5 +37,9 @@ public class ActorService {
         return favoriteActorRepository.findAllByMemberId(memberId).stream()
                 .map(FavoriteActorDto::from)
                 .collect(Collectors.toList());
+    }
+
+    public List<FavoriteActorDto> findActors(String actorName) {
+        return actorRepository.findByName(actorName);
     }
 }

--- a/src/main/java/muse_kopis/muse/actor/domain/Actor.java
+++ b/src/main/java/muse_kopis/muse/actor/domain/Actor.java
@@ -21,9 +21,11 @@ public class Actor {
     private String name;
 
     private String actorId;
+    private String url;
 
-    public Actor(String name, String actorId) {
+    public Actor(String name, String actorId, String url) {
         this.name = name;
         this.actorId = actorId;
+        this.url = url;
     }
 }

--- a/src/main/java/muse_kopis/muse/actor/domain/ActorRepository.java
+++ b/src/main/java/muse_kopis/muse/actor/domain/ActorRepository.java
@@ -1,8 +1,11 @@
 package muse_kopis.muse.actor.domain;
 
+import java.util.List;
+import muse_kopis.muse.actor.domain.dto.FavoriteActorDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ActorRepository extends JpaRepository<Actor, Long> {
+    List<FavoriteActorDto> findByName(String actorName);
 }

--- a/src/main/java/muse_kopis/muse/actor/domain/dto/CastMemberDto.java
+++ b/src/main/java/muse_kopis/muse/actor/domain/dto/CastMemberDto.java
@@ -7,13 +7,15 @@ import muse_kopis.muse.actor.domain.CastMember;
 public record CastMemberDto(
         String actorId,
         String name,
-        String role
+        String role,
+        String url
 ) {
     public static CastMemberDto from(CastMember castMember) {
         return CastMemberDto.builder()
                 .name(castMember.getActor().getName())
                 .actorId(castMember.getActor().getActorId())
                 .role(castMember.getRole())
+                .url(castMember.getActor().getUrl())
                 .build();
     }
 

--- a/src/main/java/muse_kopis/muse/actor/presentation/ActorController.java
+++ b/src/main/java/muse_kopis/muse/actor/presentation/ActorController.java
@@ -28,7 +28,7 @@ public class ActorController {
     @PostMapping
     @Operation(summary = "관심 배우 등록", description = "관심 배우를 등록합니다.")
     public ResponseEntity<Long> favorite(@Auth Long memberId, @RequestBody CastMemberDto actor) {
-        return ResponseEntity.ok().body(actorService.favorite(memberId, actor.actorId(), actor.name()));
+        return ResponseEntity.ok().body(actorService.favorite(memberId, actor.actorId(), actor.name(), actor.url()));
     }
 
     /**
@@ -40,5 +40,10 @@ public class ActorController {
     @Operation(summary = "관심 배우 조회", description = "관심 배우를 조회합니다.")
     public ResponseEntity<List<FavoriteActorDto>> favorites(@Auth Long memberId) {
         return ResponseEntity.ok().body(actorService.favorites(memberId));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<FavoriteActorDto>> findActors(@RequestParam String actorName) {
+        return ResponseEntity.ok().body(actorService.findActors(actorName));
     }
 }

--- a/src/main/java/muse_kopis/muse/genre/domain/GenreType.java
+++ b/src/main/java/muse_kopis/muse/genre/domain/GenreType.java
@@ -1,5 +1,6 @@
 package muse_kopis.muse.genre.domain;
 
+
 public enum GenreType {
     CRIME("범죄"),
     FANTASY("판타지"),

--- a/src/main/java/muse_kopis/muse/performance/infra/PerformanceClient.java
+++ b/src/main/java/muse_kopis/muse/performance/infra/PerformanceClient.java
@@ -62,7 +62,7 @@ public class PerformanceClient {
     @Retryable(value = { SQLException.class }, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public void fetchPerformances(String startDate, String endDate, String currentPage, String rows, String state, String genre) {
         String url = API_URL + "?service=" + kopisKey + "&stdate=" + startDate + "&eddate=" + endDate +
-                "&cpage=" + currentPage + "&rows=" + rows + "&prfstate=" + state+"&shcate=" + genre;
+                "&cpage=" + currentPage + "&rows=" + rows + "&prfstate=" + state + "&shcate=" + genre;
         log.info("데이터 요청 {}, {}", currentPage, state);
         String response = restTemplate.getForObject(url, String.class);
         try {
@@ -97,7 +97,7 @@ public class PerformanceClient {
                     .map(String::trim)
                     .map(name -> name.endsWith("등") ? name.substring(0, name.length() - 1).trim() : name)
                     .filter(name -> !name.isEmpty())  // 빈 문자열 필터링
-                    .map(name -> new CastMember(new Actor(name.replace("\"",""), ""), performance, ""))
+                    .map(name -> new CastMember(new Actor(name.replace("\"", ""), "", ""), performance, ""))
                     .toList();
             castMemberRepository.saveAll(castMembers);
         }

--- a/src/main/java/muse_kopis/muse/performance/presentation/PerformanceController.java
+++ b/src/main/java/muse_kopis/muse/performance/presentation/PerformanceController.java
@@ -118,7 +118,7 @@ public class PerformanceController {
         return ResponseEntity.ok().headers(headers).body(image);
     }
 
-    @PostConstruct
+//    @PostConstruct
     public void init() {
         log.info("Initialization started");
         ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();

--- a/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
+++ b/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
@@ -28,12 +28,23 @@ public class UserGenreService {
     private final PerformanceRepository performanceRepository;
     private final OauthMemberRepository oauthMemberRepository;
 
+    /**
+    * User 가 좋아요를 누르거나 티켓북을 등록하면 선호 장르 업데이트를 진행 Event 로 처리
+    */
     @EventListener
     @Transactional
     public void updateGenre(UserGenreEvent event) {
         OauthMember oauthMember = oauthMemberRepository.getByOauthMemberId(event.memberId());
         Performance performance = performanceRepository.getByPerformanceId(event.performanceId());
         weightUpdate(oauthMember, performance);
+    }
+
+    /**
+     * Onboarding 시에 초기 선호 장르 업데이틀 위해서 사용, 여러 장르를 한번에 업데이트 하기 위한 용도
+     * */
+    @Transactional
+    public void updateGenres(Long memberId, List<Long> performanceIds) {
+        performanceIds.forEach(performanceId -> updateGenre(memberId, performanceId));
     }
 
     @Transactional
@@ -52,11 +63,6 @@ public class UserGenreService {
         } catch (NullPointerException e) {
             log.warn("장르 타입이 NULL 입니다.");
         }
-    }
-
-    @Transactional
-    public void updateGenres(Long memberId, List<Long> performanceIds) {
-        performanceIds.forEach(performanceId -> updateGenre(memberId, performanceId));
     }
 
     @EventListener

--- a/src/main/java/muse_kopis/muse/usergenre/domain/UserGenre.java
+++ b/src/main/java/muse_kopis/muse/usergenre/domain/UserGenre.java
@@ -2,25 +2,20 @@ package muse_kopis.muse.usergenre.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import muse_kopis.muse.auth.oauth.domain.OauthMember;
-import muse_kopis.muse.actor.domain.FavoriteActor;
-import muse_kopis.muse.common.genre.NotFoundGenreException;
 import muse_kopis.muse.genre.domain.GenreType;
 
-@Slf4j
 @Entity
 @NoArgsConstructor
 public class UserGenre {
@@ -29,168 +24,43 @@ public class UserGenre {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated
-    private GenreType favorite;
-
-    @Enumerated
-    private GenreType second;
-
-    @Enumerated
-    private GenreType third;
-
     @OneToMany(mappedBy = "userGenre", cascade = CascadeType.ALL)
-    private List<FavoriteActor> actors;
+    private List<UserGenreWeight> genreWeights = new ArrayList<>();
 
     @OneToOne
     private OauthMember oauthMember;
 
-    private Integer crime;
-    private Integer fantasy;
-    private Integer fairyTale;
-    private Integer family;
-    private Integer adventure;
-    private Integer healing;
-    private Integer romance;
-    private Integer child;
-    private Integer thriller;
-    private Integer history;
-    private Integer drama;
-    private Integer philosophy;
-    private Integer jazz;
-    private Integer humor;
-    private Integer comedy;
-    private Integer rock;
-    private Integer action;
-    private Integer office;
-    private Integer parody;
-    private Integer nonverbal;
-    private Integer performance;
-    private Integer art;
-    private Integer interactive;
-    private Integer emotion;
-    private Integer youthfulGrowth;
-    private Integer cabaret;
-    private Integer female;
-    private Integer band;
-    private Integer religion;
-    private Integer classicNovel;
-    private Integer talkConcert;
+    @Enumerated(EnumType.STRING)
+    private GenreType favorite;
+
+    @Enumerated(EnumType.STRING)
+    private GenreType second;
+
+    @Enumerated(EnumType.STRING)
+    private GenreType third;
 
     public UserGenre(OauthMember oauthMember) {
         this.oauthMember = oauthMember;
-        this.crime = 0;
-        this.fantasy = 0;
-        this.fairyTale = 0;
-        this.family = 0;
-        this.adventure = 0;
-        this.healing = 0;
-        this.romance = 0;
-        this.child = 0;
-        this.thriller = 0;
-        this.history = 0;
-        this.drama = 0;
-        this.philosophy = 0;
-        this.jazz = 0;
-        this.humor = 0;
-        this.comedy = 0;
-        this.rock = 0;
-        this.action = 0;
-        this.office = 0;
-        this.parody = 0;
-        this.nonverbal = 0;
-        this.performance = 0;
-        this.art = 0;
-        this.interactive = 0;
-        this.emotion = 0;
-        this.youthfulGrowth = 0;
-        this.cabaret = 0;
-        this.female = 0;
-        this.band = 0;
-        this.religion = 0;
-        this.classicNovel = 0;
-        this.talkConcert = 0;
+        for (GenreType genre : GenreType.values()) {
+            genreWeights.add(new UserGenreWeight(genre, 0, this));
+        }
     }
 
     public void incrementGenreWeight(GenreType genreType) {
-        if(genreType == null) {
-            throw new NullPointerException();
-        }
-        switch (genreType) {
-            case CRIME -> crime++;
-            case FANTASY -> fantasy++;
-            case FAIRY_TALE -> fairyTale++;
-            case FAMILY -> family++;
-            case ADVENTURE -> adventure++;
-            case HEALING -> healing++;
-            case ROMANCE -> romance++;
-            case CHILD -> child++;
-            case THRILLER -> thriller++;
-            case HISTORY -> history++;
-            case DRAMA -> drama++;
-            case PHILOSOPHY -> philosophy++;
-            case JAZZ -> jazz++;
-            case HUMOR -> humor++;
-            case COMEDY -> comedy++;
-            case ROCK -> rock++;
-            case ACTION -> action++;
-            case OFFICE -> office++;
-            case PARODY -> parody++;
-            case NON_VERBAL -> nonverbal++;
-            case PERFORMANCE -> performance++;
-            case ART -> art++;
-            case INTERACTIVE -> interactive++;
-            case EMOTION -> emotion++;
-            case YOUTHFUL_GROWTH -> youthfulGrowth++;
-            case CABARET -> cabaret++;
-            case FEMALE_ONLY -> female++;
-            case BAND_MUSICAL -> band++;
-            case RELIGION -> religion++;
-            case CLASSIC_NOVEL -> classicNovel++;
-            case TALK_CONCERT -> talkConcert++;
-            default -> throw new NotFoundGenreException("해당 장르가 존재하지 않습니다. \"" + genreType.name() + "\"");
-        }
+        genreWeights.stream()
+                .filter(gw -> gw.getGenreType() == genreType)
+                .findAny()
+                .ifPresent(UserGenreWeight::incrementWeight);
         updateFavoriteGenre();
     }
 
     private void updateFavoriteGenre() {
-        Map<GenreType, Integer> genreWeights = new HashMap<>();
-        genreWeights.put(GenreType.CRIME, crime);
-        genreWeights.put(GenreType.FANTASY, fantasy);
-        genreWeights.put(GenreType.FAIRY_TALE, fairyTale);
-        genreWeights.put(GenreType.FAMILY, family);
-        genreWeights.put(GenreType.ADVENTURE, adventure);
-        genreWeights.put(GenreType.HEALING, healing);
-        genreWeights.put(GenreType.ROMANCE, romance);
-        genreWeights.put(GenreType.CHILD, child);
-        genreWeights.put(GenreType.THRILLER, thriller);
-        genreWeights.put(GenreType.HISTORY, history);
-        genreWeights.put(GenreType.DRAMA, drama);
-        genreWeights.put(GenreType.PHILOSOPHY, philosophy);
-        genreWeights.put(GenreType.JAZZ, jazz);
-        genreWeights.put(GenreType.HUMOR, humor);
-        genreWeights.put(GenreType.COMEDY, comedy);
-        genreWeights.put(GenreType.ROCK, rock);
-        genreWeights.put(GenreType.ACTION, action);
-        genreWeights.put(GenreType.OFFICE, office);
-        genreWeights.put(GenreType.PARODY, parody);
-        genreWeights.put(GenreType.NON_VERBAL, nonverbal);
-        genreWeights.put(GenreType.PERFORMANCE, performance);
-        genreWeights.put(GenreType.ART, art);
-        genreWeights.put(GenreType.INTERACTIVE, interactive);
-        genreWeights.put(GenreType.EMOTION, emotion);
-        genreWeights.put(GenreType.YOUTHFUL_GROWTH, youthfulGrowth);
-        genreWeights.put(GenreType.CABARET, cabaret);
-        genreWeights.put(GenreType.FEMALE_ONLY, female);
-        genreWeights.put(GenreType.BAND_MUSICAL, band);
-        genreWeights.put(GenreType.RELIGION, religion);
-        genreWeights.put(GenreType.CLASSIC_NOVEL, classicNovel);
-        genreWeights.put(GenreType.TALK_CONCERT, talkConcert);
-        List<Entry<GenreType, Integer>> collect = genreWeights.entrySet().stream()
-                .sorted(Entry.comparingByValue(Comparator.reverseOrder()))
-                .limit(3).toList();
-        favorite = collect.get(0).getKey();
-        second = collect.get(1).getKey();
-        third = collect.get(2).getKey();
+        genreWeights.sort(Comparator.comparing(UserGenreWeight::getWeight).reversed());
+        if (genreWeights.size() >= 3) {
+            favorite = genreWeights.get(0).getGenreType();
+            second = genreWeights.get(1).getGenreType();
+            third = genreWeights.get(2).getGenreType();
+        }
     }
 
     public GenreType favorite() {
@@ -203,9 +73,5 @@ public class UserGenre {
 
     public GenreType third() {
         return third;
-    }
-
-    public List<FavoriteActor> favoriteActors() {
-        return actors;
     }
 }

--- a/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreRepository.java
+++ b/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreRepository.java
@@ -11,5 +11,6 @@ public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
         return findByOauthMember(oauthMember)
                 .orElseThrow(() -> new NotFoundMemberException("존재하지 않는 회원입니다."));
     }
+
     Optional<UserGenre> findByOauthMember(OauthMember oauthMember);
 }

--- a/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreWeight.java
+++ b/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreWeight.java
@@ -1,0 +1,42 @@
+package muse_kopis.muse.usergenre.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muse_kopis.muse.genre.domain.GenreType;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserGenreWeight {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private GenreType genreType;
+
+    private Integer weight = 0;
+
+    @ManyToOne
+    @JoinColumn(name = "user_genre_id")
+    private UserGenre userGenre;
+
+    public UserGenreWeight(GenreType genreType, Integer weight, UserGenre userGenre) {
+        this.genreType = genreType;
+        this.weight = weight;
+        this.userGenre = userGenre;
+    }
+
+    public void incrementWeight() {
+        this.weight++;
+    }
+}

--- a/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreWeightRepository.java
+++ b/src/main/java/muse_kopis/muse/usergenre/domain/UserGenreWeightRepository.java
@@ -1,0 +1,6 @@
+package muse_kopis.muse.usergenre.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGenreWeightRepository extends JpaRepository<UserGenreWeight, Long> {
+}


### PR DESCRIPTION
#35 close
사용자 장르 테이블의 엔티티로 모두 들어가 있던 장르 값을 weight로 바꾸어서 코드의 확장성을 만들고, 하드 코딩을 제거하여 유지보수를 쉽게 할 수 있게 만들었습니다.