### PR TITLE
fix: RAND() 허용 문제 수정

### DIFF
--- a/src/main/java/muse_kopis/muse/performance/domain/PerformanceRepository.java
+++ b/src/main/java/muse_kopis/muse/performance/domain/PerformanceRepository.java
@@ -56,17 +56,21 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     List<Performance> findPerformancesByFavoriteActor(@Param("favoriteActor") String favoriteActor);
 
     @Query(value = """
-        WITH RandomizedPerformances AS (
+    WITH RandomizedPerformances AS (
+        SELECT
+            p.*,
+            ROW_NUMBER() OVER (PARTITION BY p.genre_type ORDER BY p.random_val) AS rn
+        FROM (
             SELECT
-                p.*,
-                ROW_NUMBER() OVER(PARTITION BY p.genre_type ORDER BY RAND()) as rn
+                p.*, RAND() AS random_val
             FROM
                 performance p
             WHERE
                 p.genre_type IN :genres
-        )
-        SELECT * FROM RandomizedPerformances WHERE rn <= :limitPerGenre
-    """, nativeQuery = true)
+        ) p
+    )
+    SELECT * FROM RandomizedPerformances WHERE rn <= :limitPerGenre
+""", nativeQuery = true)
     List<Performance> findRandomSamplesByGenreNames(
             @Param("genres") List<String> genres,
             @Param("limitPerGenre") int limitPerGenre


### PR DESCRIPTION
MySQL에서 ROW_NUMBER() OVER (ORDER BY RAND()) 구문 허용 문제 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the random sampling logic for genre-based selections to produce more balanced, evenly distributed results per genre when limits are applied.
  * Users may notice more varied and fair genre mixes in random selections or recommendations, with improved consistency across repeated refreshes and reduced clustering.
  * No changes to settings or workflows; overall browsing should feel more balanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->